### PR TITLE
[system-health] [update] Add fan direction check to system health

### DIFF
--- a/doc/system_health_monitoring/system-health-HLD.md
+++ b/doc/system_health_monitoring/system-health-HLD.md
@@ -55,6 +55,7 @@ By default any service is not in expected status will be considered as fault con
 
 -  Any fan is missing/broken
 -  Fan speed is lower than minimal value
+-  Fan direction is not expected
 -  PSU power voltage is out of range
 -  PSU temperature is higher than threshold
 -  PSU is in bad status
@@ -77,8 +78,10 @@ The filter string is case sensitive. Currently, it support following filters:
 - asic: ignore all ASIC check
 - fan: ignore all fan check
 - fan.speed: ignore fan speed check
+- fan.direction: ignore fan direction check
 - <fan_name>: ignore check for a specific fan
 - <fan_name>.speed: ignore speed check for a specific fan
+- <fan_name>.direction: ignore direction check for a specific fan
 - psu: ignore all PSU check
 - psu.temperature: ignore temperature check for all PSUs
 - psu.voltage: ignore voltage check for all PSUs
@@ -300,6 +303,7 @@ Fault condition and CLI output string table
  | critical service failure|[service name] is [service status]|
  | Any fan is missing/broken   |[FAN name] is missing/broken|
  | Fan speed is below minimal range|[FAN name] speed is lower than expected|
+ | Fan direction is wrong|[FAN name] direction is wrong, expected:[value], got:[value]|
  | PSU power voltage is out of range|[PSU name] voltage is out of range|
  | PSU power exceeds threshold|[PSU name] power exceeds threshold|
  | PSU temp is too hot|[PSU name] is overheated|

--- a/doc/system_health_monitoring/system-health-HLD.md
+++ b/doc/system_health_monitoring/system-health-HLD.md
@@ -56,6 +56,8 @@ By default any service is not in expected status will be considered as fault con
 -  Any fan is missing/broken
 -  Fan speed is lower than minimal value
 -  Fan direction is not expected
+    - All fan direction must be the same
+    - Fan direction with 'N/A' or none will be ignored
 -  PSU power voltage is out of range
 -  PSU temperature is higher than threshold
 -  PSU is in bad status


### PR DESCRIPTION
**What I did?**
Add a fan direction check to system health.

**Why I did this?**
Correct airflow is very important for a switch system to prevent it from overheating. Incorrect airflow would cause abnormal system temperature raising and it is difficult to debug it without open the switch box. 

As fan direction is already queried and stored to DB by thermalctld, system-health service should monitor fan direction and raise alarm if fan direction is not correct. 